### PR TITLE
feat(dualpidpcm): hystérésis sur la tension batterie

### DIFF
--- a/code/device_dualpidpcm.yaml
+++ b/code/device_dualpidpcm.yaml
@@ -180,9 +180,11 @@ number:
     dualpidpcm_id: ${dualpidpcm_id}
     setpoint:
       name: ${name}_${dualpidpcm_name}_setpoint
-    starting_battery_voltage: 
+    starting_battery_voltage:                     # seuil HAUT (redémarrage)
       name: ${name}_${dualpidpcm_name}_starting_battery_voltage
-    kp: 
+    stopping_battery_voltage:                     # seuil BAS (arrêt)
+      name: ${name}_${dualpidpcm_name}_stopping_battery_voltage
+    kp:
       name: ${name}_${dualpidpcm_name}_kp
     ki: 
       name: ${name}_${dualpidpcm_name}_ki

--- a/components/dualpidpcm/dualpidpcm.cpp
+++ b/components/dualpidpcm/dualpidpcm.cpp
@@ -644,10 +644,22 @@ void DUALPIDPCMComponent::pid_update() {
     this->current_output_charging_    = std::min(std::max(this->current_output_charging_, this->current_output_min_charging_), this->current_output_max_charging_);
     this->current_output_discharging_ = std::min(std::max(this->current_output_discharging_, this->current_output_min_discharging_), this->current_output_max_discharging_);
 
-    // ── Protection sous-tension batterie ─────────────────────────────
+    // ── Protection sous-tension batterie (hystérésis) ─────────────────
     if (!std::isnan(this->current_battery_voltage_)) {
-        ESP_LOGI(TAG, "battery_voltage = %2.2f, starting battery voltage = %2.2f", this->current_battery_voltage_, this->current_starting_battery_voltage_);
-        if (this->current_battery_voltage_ < this->current_starting_battery_voltage_) {
+        ESP_LOGI(TAG, "battery_voltage = %2.2f, stop = %2.2f, start = %2.2f, lockout = %d",
+                 this->current_battery_voltage_,
+                 this->current_stopping_battery_voltage_,
+                 this->current_starting_battery_voltage_,
+                 this->undervoltage_lockout_);
+
+        if (this->current_battery_voltage_ < this->current_stopping_battery_voltage_) {
+            this->undervoltage_lockout_ = true;                       // arrêt
+        } else if (this->current_battery_voltage_ >= this->current_starting_battery_voltage_) {
+            this->undervoltage_lockout_ = false;                      // redémarrage
+        }
+        // entre les deux seuils : on garde l'état courant (hystérésis)
+
+        if (this->undervoltage_lockout_) {
             this->set_charging_level(0.0f);
             this->set_discharging_level(0.0f);
             this->current_output_             = this->oneutral_;

--- a/components/dualpidpcm/dualpidpcm.h
+++ b/components/dualpidpcm/dualpidpcm.h
@@ -29,6 +29,7 @@ class DUALPIDPCMComponent : public Component{
 
  SUB_NUMBER(setpoint)
  SUB_NUMBER(feedforward_threshold)
+ SUB_NUMBER(stopping_battery_voltage)
  SUB_NUMBER(starting_battery_voltage)
  SUB_NUMBER(kp)
  SUB_NUMBER(ki)
@@ -85,6 +86,9 @@ class DUALPIDPCMComponent : public Component{
   void set_feedforward_threshold(float value) {this->current_feedforward_threshold_ = value;}
   float get_feedforward_threshold(void){return this->current_feedforward_threshold_;}
   
+  void set_stopping_battery_voltage(float value) {this->current_stopping_battery_voltage_ = value;}
+  float get_stopping_battery_voltage(void){return this->current_stopping_battery_voltage_;}
+
   void set_starting_battery_voltage(float value) {this->current_starting_battery_voltage_ = value;}
   float get_starting_battery_voltage(void){return this->current_starting_battery_voltage_;}
 
@@ -170,7 +174,9 @@ class DUALPIDPCMComponent : public Component{
 
   float current_setpoint_ = 0.0f;
   float current_feedforward_threshold_ = 300.0f;
-  float current_starting_battery_voltage_ = 51.0f;
+  float current_stopping_battery_voltage_ = 51.0f;   // seuil bas (arrêt)
+  float current_starting_battery_voltage_ = 52.0f;   // seuil haut (redémarrage), doit rester > stopping
+  bool  undervoltage_lockout_             = false;   // état d'hystérésis latché
 
   float current_kp_          = 1.1f;
   float current_ki_          = 0.0f;

--- a/components/dualpidpcm/number/__init__.py
+++ b/components/dualpidpcm/number/__init__.py
@@ -22,6 +22,7 @@ from .. import CONF_DUALPIDPCM_ID, DUALPIDPCMComponent, dualpidpcm_ns
 
 SetpointNumber = dualpidpcm_ns.class_("SetpointNumber", number.Number, cg.Component)
 StartingBatteryVoltageNumber = dualpidpcm_ns.class_("StartingBatteryVoltageNumber", number.Number, cg.Component)
+StoppingBatteryVoltageNumber = dualpidpcm_ns.class_("StoppingBatteryVoltageNumber", number.Number, cg.Component)
 
 
 KpNumber = dualpidpcm_ns.class_("KpNumber", number.Number, cg.Component)
@@ -38,6 +39,7 @@ FeedforwardthresholdNumber = dualpidpcm_ns.class_("FeedforwardthresholdNumber", 
 
 CONF_SETPOINT = "setpoint"
 CONF_STARTING_BATTERY_VOLTAGE = "starting_battery_voltage"
+CONF_STOPPING_BATTERY_VOLTAGE = "stopping_battery_voltage"
 
 
 CONF_KP = "kp"
@@ -66,6 +68,14 @@ CONFIG_SCHEMA = {
     
     cv.Optional(CONF_STARTING_BATTERY_VOLTAGE): number.number_schema(
         StartingBatteryVoltageNumber,
+        device_class=DEVICE_CLASS_VOLTAGE,
+        icon = ICON_SINE_WAVE,
+        unit_of_measurement=UNIT_VOLT,
+        entity_category=ENTITY_CATEGORY_CONFIG
+    ).extend(cv.COMPONENT_SCHEMA),
+
+    cv.Optional(CONF_STOPPING_BATTERY_VOLTAGE): number.number_schema(
+        StoppingBatteryVoltageNumber,
         device_class=DEVICE_CLASS_VOLTAGE,
         icon = ICON_SINE_WAVE,
         unit_of_measurement=UNIT_VOLT,
@@ -143,6 +153,14 @@ async def to_code(config):
         await cg.register_component(n, starting_battery_voltage_config)
         await cg.register_parented(n, dualpidpcm_component)
         cg.add(dualpidpcm_component.set_starting_battery_voltage_number(n))
+
+  if stopping_battery_voltage_config := config.get(CONF_STOPPING_BATTERY_VOLTAGE):
+        n = await number.new_number(
+            stopping_battery_voltage_config, min_value=50.0, max_value=60.0, step=0.1
+        )
+        await cg.register_component(n, stopping_battery_voltage_config)
+        await cg.register_parented(n, dualpidpcm_component)
+        cg.add(dualpidpcm_component.set_stopping_battery_voltage_number(n))
 
   if kp_config := config.get(CONF_KP):
         n = await number.new_number(

--- a/components/dualpidpcm/number/stopping_battery_voltage_number.cpp
+++ b/components/dualpidpcm/number/stopping_battery_voltage_number.cpp
@@ -1,0 +1,21 @@
+#include "stopping_battery_voltage_number.h"
+
+namespace esphome {
+namespace dualpidpcm {
+
+void StoppingBatteryVoltageNumber::setup() {
+  float value;
+  this->pref_ = global_preferences->make_preference<float>(this->get_object_id_hash());
+  if (!this->pref_.load(&value)) value = this->parent_->get_stopping_battery_voltage();
+  this->parent_->set_stopping_battery_voltage(value);
+  this->publish_state(value);
+}
+
+void StoppingBatteryVoltageNumber::control(float value) {
+  this->publish_state(value);
+  this->parent_->set_stopping_battery_voltage(value);
+  this->pref_.save(&value);
+}
+
+}  // namespace dualpidpcm
+}  // namespace esphome

--- a/components/dualpidpcm/number/stopping_battery_voltage_number.h
+++ b/components/dualpidpcm/number/stopping_battery_voltage_number.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "esphome/components/number/number.h"
+#include "../dualpidpcm.h"
+
+namespace esphome {
+namespace dualpidpcm {
+
+class StoppingBatteryVoltageNumber : public number::Number, public Component, public Parented<DUALPIDPCMComponent> {
+ public:
+  void setup() override;
+
+ protected:
+  void control(float value) override;
+  ESPPreferenceObject pref_;
+};
+
+}  // namespace dualpidpcm
+}  // namespace esphome


### PR DESCRIPTION
Hello,

Petite proposition d'amélioration:
La protection sous-tension n'avait qu'un seul seuil : dès que la tension repassait au-dessus, la régulation redémarrait aussitôt, ce qui pouvait faire battre le système autour du seuil. Le number "starting_battery_voltage" était en plus mal nommé puisqu'il servait en réalité à couper.

On passe donc à deux seuils avec un état latché (undervoltage_lockout_) :
- stopping_battery_voltage : seuil bas, la tension descend jusque-là -> arrêt
- starting_battery_voltage : seuil haut, la tension remonte jusque-là -> redémarrage Entre les deux on conserve l'état courant, d'où l'hystérésis.

L'ancien starting devient stopping (seuil bas, comportement inchangé) et starting est réattribué au nouveau seuil haut de redémarrage.